### PR TITLE
feat: place mould on the execute pwd rather than nodejs project root

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -5,15 +5,6 @@ import path from 'path'
 import { paths } from '../constants'
 import { useYarn } from '../utils'
 
-if (!fs.existsSync(path.join(paths.rootDirectory, 'package.json'))) {
-    console.error(
-        `Please, run ${chalk.cyan(
-            `${useYarn() ? 'yarn' : 'npx'} mould init`
-        )} within your project directory`
-    )
-    process.exit(1)
-}
-
 if (fs.existsSync(paths.mouldDirectory)) {
     console.warn(
         `You already have ${chalk.green(

--- a/utils/resolvePath.js
+++ b/utils/resolvePath.js
@@ -1,5 +1,5 @@
 import path from 'path'
 
 export default function resolvePath(relativePath = '.') {
-    return path.resolve(process.cwd(), relativePath)
+    return path.resolve(process.env.INIT_CWD, relativePath)
 }


### PR DESCRIPTION
We init mould directory on nodejs project root before. It will not support CRA cause the CRA only allow import codes/assets from src.

And for now, we don't build anything to node_modules/git-ignored directory. I found we may try a freely way that thought mould directory as code containing some components. We can put it anywhere in a project and one project can contain multi mould directories.

----

For CRA usage:
```
cd src
yarn mould init
yarn mould connect
```

```
A CRA Repo:
  - src
    - mould
      - .mould
      - resolvers
    - App.js
  - package.json
```