### PR TITLE
fix: recursively initialize mould

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -21,7 +21,7 @@ if (fs.existsSync(paths.mouldDirectory)) {
         )} initialized at ${chalk.green(paths.rootDirectory)}`
     )
 } else {
-    fs.mkdirSync(paths.mouldDirectory)
+    fs.mkdirSync(paths.mouldDirectory, { recursive: true })
 
     console.log(
         `Created ${chalk.green(path.basename(paths.mouldDirectory))} ` +


### PR DESCRIPTION
```sh
$ yarn mould init temp/dit/to/test

Created mould directory at /Users/rostislav/Projects/mouldjs/react-app-ts/temp/dit/to/test
Created resolvers.ts at /Users/rostislav/Projects/mouldjs/react-app-ts/temp/dit/to/test/mould
Created setup.ts at /Users/rostislav/Projects/mouldjs/react-app-ts/temp/dit/to/test/mould

You could begin by typing:

  yarn mould connect temp/dit/to/test

Or you could add mould connect temp/dit/to/test to your package.json scripts

✨  Done in 0.84s.
```