### PR TITLE
increase payload limit to 100mb

### DIFF
--- a/commands/connect.js
+++ b/commands/connect.js
@@ -23,7 +23,13 @@ const app = express()
 
 const server = new ApolloServer({ schema })
 
-server.applyMiddleware({ app, path: '/api/graphql' })
+server.applyMiddleware({
+    app,
+    path: '/api/graphql',
+    bodyParserConfig: {
+        limit: '100mb',
+    },
+})
 
 app.listen({ port: 4000 }, () =>
     console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)


### PR DESCRIPTION
resolve this issue: `PayloadTooLargeError: request entity too large`

https://medium.com/codespace69/node-js-graphql-request-entity-too-large-payloadtoolargeerror-request-entity-too-large-a0c76a64241c