### PR TITLE
feat: add index for importhing components from mould dir

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -29,6 +29,18 @@ if (fs.existsSync(paths.mouldDirectory)) {
     )
 }
 
+if (!fs.existsSync(paths.index)) {
+    fs.writeFileSync(
+        paths.index,
+        "export * from '!!babel-loader!@binance/mloader!./.mould'"
+    )
+
+    console.log(
+        `Created ${chalk.green(path.basename(paths.index))} ` +
+            `at ${chalk.green(paths.mouldDirectory)}`
+    )
+}
+
 if (!fs.existsSync(paths.resolvers)) {
     fs.writeFileSync(paths.resolvers, 'export default {}')
 

--- a/constants/paths.js
+++ b/constants/paths.js
@@ -5,4 +5,5 @@ export default {
     mouldDirectory: resolvePath('mould'),
     schema: resolvePath('mould/.mould'),
     resolvers: resolvePath(`mould/resolvers.${useTs() ? 'ts' : 'js'}`),
+    index: resolvePath('mould/index.js'),
 }


### PR DESCRIPTION
#### CRA
CRA is pretty straightforward

```js
src
├─mould
│ ├─.babelrc
│ ├─.mould
│ ├─index.js:
│ │   export * from '!!babel-loader!@binance/mloader!./.mould'
│ └─resolvers.js
└─App.js:
    import React from 'react'
    import { Header } from './mould'
```

#### Next.js
Next.js needs an extra attention because of the issue:
```
Syntax error: Using `export * from '...'` in a page is disallowed. Please use `export { default } from '...'` instead.
Read more: https://err.sh/next.js/export-all-in-page
```

```js
pages
└─about
  ├─mould
  │ ├─.babelrc
  │ ├─.mould
  │ ├─index.js:
  │ │   import * as mould from '!!babel-loader!@binance/mloader!./.mould'
  │ │   export default mould
  │ └─resolvers.js
  └─index.js:
      import mould from './mould'
      const { Header } = mould
```

#### CRA with typescript
This combination requires further accommodation, because we need to provide the module declaration, for example
```js
src
├─mould
│ ├─.babelrc
│ ├─.mould
│ ├─babel-loader.d.ts
│ │   /// <reference types="react" />
│ │   
│ │   declare module "!!babel-loader!*" {
│ │       export declare function Header(props: any): JSX.Element | null;
│ │   }
│ ├─index.ts:
│ │   export * from '!!babel-loader!@binance/mloader!./.mould'
│ └─resolvers.ts
└─App.ts:
    import React from 'react'
    import { Header } from './mould'
```